### PR TITLE
removed unused dependency

### DIFF
--- a/impl/c-qube/package.json
+++ b/impl/c-qube/package.json
@@ -44,7 +44,6 @@
     "lodash": "^4.17.21",
     "nestjs-pino": "^3.1.2",
     "nodejs-polars": "^0.7.2",
-    "nodejs-polars-linux-x64-gnu": "^0.7.2",
     "pg": "^8.10.0",
     "picocolors": "^1.0.0",
     "pino-http": "^8.3.3",


### PR DESCRIPTION
Removed the dependency - `nodejs-polars-linux-x64-gnu@0.7.2` as the installation of platform-specific dependency is handled by the `nodejs-polars`. For further confirmation from the library maintainers, you can look [here](https://stackoverflow.com/questions/76635638/who-decides-what-optional-dependencies-to-install-when-installing-nodejs-polars/76641011#76641011).

After the changes, the unit-tests seem to run fine but the e2e tests are failing (independent of the changes)